### PR TITLE
Utilize index on AcctStartTime

### DIFF
--- a/.docker/rootfs/etc/raddb/mods-available/sqlcounter
+++ b/.docker/rootfs/etc/raddb/mods-available/sqlcounter
@@ -103,5 +103,5 @@ sqlcounter monthlytrafficcounter {
     sqlmod_inst = sql
     key = User-Name
     reset = monthly
-    query = "SELECT SUM(acctinputoctets + acctoutputoctets) DIV 1024 FROM radacct WHERE UserName='%{${key}}' AND UNIX_TIMESTAMP(AcctStartTime) > '%%b'"
+    query = "SELECT SUM(acctinputoctets + acctoutputoctets) DIV 1024 FROM radacct WHERE UserName='%{${key}}' AND AcctStartTime > FROM_UNIXTIME('%%b')"
 }


### PR DESCRIPTION
https://dba.stackexchange.com/questions/28310/is-a-query-with-unix-timestamp-using-indexes-in-mysql

Compare:

```
mysql> SELECT count(*) FROM radacct WHERE UserName='test@example.com' AND AcctStartTime > FROM_UNIXTIME('1709251200');
+----------+
| count(*) |
+----------+
|     4590 |
+----------+
1 row in set (0.05 sec)

mysql> SELECT count(*) FROM radacct WHERE UserName='test@example.com' AND UNIX_TIMESTAMP(AcctStartTime) > '1709251200';
+----------+
| count(*) |
+----------+
|     4590 |
+----------+
1 row in set (1.37 sec)
```