### PR TITLE
Fix accounting stop handling in MySQL strict mode

### DIFF
--- a/.docker/rootfs/etc/raddb/mods-config/sql/main/mysql/queries.conf
+++ b/.docker/rootfs/etc/raddb/mods-config/sql/main/mysql/queries.conf
@@ -345,7 +345,7 @@ accounting {
 				UPDATE ${....acct_table2} SET \
 					acctstoptime	= FROM_UNIXTIME(\
 						%{integer:Event-Timestamp}), \
-					acctsessiontime	= '%{Acct-Session-Time}', \
+					acctsessiontime	= '%{%{Acct-Session-Time}:-0}', \
 					acctinputoctets	= '%{%{Acct-Input-Gigawords}:-0}' \
 						<< 32 | '%{%{Acct-Input-Octets}:-0}', \
 					acctoutputoctets = '%{%{Acct-Output-Gigawords}:-0}' \


### PR DESCRIPTION
https://github.com/billzhong/squidlog/blob/f1dcaef70eb2aa21253682b1d9c754da784e473b/squid2radius.py#L81-L103 does not have Acct-Session-Time in their stop-type acct packet, which would make MySQL 8 in default (strict) mode complain:

ERROR 1366 (Incorrect integer value: '' for column 'acctsessiontime' at row 1)

This commit sets a default value 0 for acctsessiontime in this case.